### PR TITLE
Add postgres service for test flow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,7 +6,26 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    env:
+      DATABASE_PASSWORD: postgres
+      DATABASE_USER: postgres
+      DATABASE_NAME: draft_test
+      DATABASE_HOST: localhost
+      DRAFT_AUTH_SECRET: test_auth_secret
+      SECRET_KEY_BASE: local_secret_key_base_at_least_64_bytes_________________________________
       
+    services:
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: ${{env.DATABASE_PASSWORD}}
+          POSTGRES_USER:  ${{env.DATABASE_USER}}
+          POSTGRES_DB: ${{env.DATABASE_NAME}}
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+
     steps:
     - uses: actions/checkout@v2
     # cache the ASDF directory, using the values from .tool-versions

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,7 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-  config :ueberauth, Ueberauth,
+config :ueberauth, Ueberauth,
   providers: [
     cognito: {Ueberauth.Strategy.Cognito, []}
   ]

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Draft.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
+      test_coverage: [tool: LcovEx, output: "coverage", ignore_paths: ~w(test/ src/)],
       dialyzer: [
         plt_add_apps: [:mix],
         plt_add_deps: :transitive,

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Draft.MixProject do
       {:phoenix, "~> 1.5.8"},
       {:phoenix_ecto, "~> 4.1"},
       {:ecto_sql, "~> 3.4"},
+      {:lcov_ex, "~> 0.1.1", only: :test, runtime: false},
       {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -20,6 +20,7 @@
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~>0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "jose": {:hex, :jose, "1.11.1", "59da64010c69aad6cde2f5b9248b896b84472e99bd18f246085b7b9fe435dcdb", [:mix, :rebar3], [], "hexpm", "078f6c9fb3cd2f4cfafc972c814261a7d1e8d2b3685c0a76eb87e158efff1ac5"},
+  "lcov_ex": {:hex, :lcov_ex, "0.1.1", "73994c7e806ccd45d9ac7431fa388feeb613ad7657142da3120fb8c35125efc0", [:mix], [], "hexpm", "e981ff5259b0c6845333579d3e9f0d766a1afa7eed9394792a045f44b854305d"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1199987702860136/1200240419411845
This PR adds a postgres service container to the test workflow. Without a postgres db, the tests cannot be run. 

I tested this change locally using https://github.com/nektos/act. However, I found there was an [issue](https://github.com/nektos/act/issues/173) where services did not work when testing locally . Followed [this](https://mauricius.dev/run-and-debug-github-actions-locally/) tutorial to start a postgres container locally for testing and confirmed I was able to get the tests to run from this workflow. 
![image](https://user-images.githubusercontent.com/31781298/118135246-c8e5b980-b3d0-11eb-96c7-d7c5222f5adb.png)
