### PR TITLE
Cleanup based on credo output

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -63,7 +63,7 @@
       #
       # To disable a check put `false` as second element:
       #
-      #     {Credo.Check.Design.DuplicatedCode, false}
+      #     {Credo.Check.Design.DuplicatedCode, []}
       #
       checks: [
         #
@@ -157,25 +157,25 @@
         #
         # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
         #
-        {Credo.Check.Readability.StrictModuleLayout, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-        {Credo.Check.Consistency.UnusedVariableNames, false},
-        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Readability.StrictModuleLayout, []},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+        {Credo.Check.Consistency.UnusedVariableNames, []},
+        {Credo.Check.Design.DuplicatedCode, []},
         {Credo.Check.Readability.AliasAs, false},
-        {Credo.Check.Readability.MultiAlias, false},
-        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.MultiAlias, []},
+        {Credo.Check.Readability.Specs, []},
         {Credo.Check.Readability.SinglePipe, []},
-        {Credo.Check.Readability.WithCustomTaggedTuple, false},
-        {Credo.Check.Refactor.ABCSize, false},
-        {Credo.Check.Refactor.AppendSingleItem, false},
-        {Credo.Check.Refactor.DoubleBooleanNegation, false},
+        {Credo.Check.Readability.WithCustomTaggedTuple, []},
+        {Credo.Check.Refactor.ABCSize, []},
+        {Credo.Check.Refactor.AppendSingleItem, []},
+        {Credo.Check.Refactor.DoubleBooleanNegation, []},
         {Credo.Check.Refactor.ModuleDependencies, false},
-        {Credo.Check.Refactor.NegatedIsNil, false},
+        {Credo.Check.Refactor.NegatedIsNil, []},
         {Credo.Check.Refactor.PipeChainStart, []},
-        {Credo.Check.Refactor.VariableRebinding, false},
-        {Credo.Check.Warning.LeakyEnvironment, false},
-        {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Warning.UnsafeToAtom, false}
+        {Credo.Check.Refactor.VariableRebinding, []},
+        {Credo.Check.Warning.LeakyEnvironment, []},
+        {Credo.Check.Warning.MapGetUnsafePass, []},
+        {Credo.Check.Warning.UnsafeToAtom, []}
 
         #
         # Custom checks can be created using `mix credo.gen.check`.

--- a/lib/draft/application.ex
+++ b/lib/draft/application.ex
@@ -5,6 +5,7 @@ defmodule Draft.Application do
 
   use Application
 
+  @spec start(any, any) :: {:error, any} | {:ok, pid}
   def start(_type, _args) do
     children = [
       # Start the Ecto repository
@@ -27,6 +28,7 @@ defmodule Draft.Application do
 
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
+  @spec config_change(any, any, any) :: :ok
   def config_change(changed, _new, removed) do
     DraftWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/lib/draft/repo.ex
+++ b/lib/draft/repo.ex
@@ -10,6 +10,7 @@ defmodule Draft.Repo do
   invoked prior to each DB connection. `config` is the configured connection values
   and it returns a new set of config values to be used when connecting.
   """
+  @spec before_connect(map()) :: map()
   def before_connect(config) do
     mod = Application.get_env(:draft, :aws_rds_mod)
 

--- a/lib/draft_web/auth_manager.ex
+++ b/lib/draft_web/auth_manager.ex
@@ -17,7 +17,7 @@ defmodule DraftWeb.AuthManager do
   end
 
   @spec resource_from_claims(claims :: Guardian.Token.claims()) ::
-          {:error, :invalid_claims} | {:ok, any}
+          {:error, :invalid_claims} | {:ok, String.t()}
   def resource_from_claims(%{"sub" => username}) do
     {:ok, username}
   end

--- a/lib/draft_web/auth_manager.ex
+++ b/lib/draft_web/auth_manager.ex
@@ -8,16 +8,21 @@ defmodule DraftWeb.AuthManager do
 
   @draft_admin_group "draft-admin"
 
+  @spec subject_for_token(
+          resource :: Guardian.Token.resource(),
+          claims :: Guardian.Token.claims()
+        ) :: {:ok, String.t()} | {:error, atom()}
   def subject_for_token(resource, _claims) do
     {:ok, resource}
   end
 
-  @spec resource_from_claims(any) :: {:error, :invalid_claims} | {:ok, any}
+  @spec resource_from_claims(claims :: Guardian.Token.claims()) ::
+          {:error, :invalid_claims} | {:ok, any}
   def resource_from_claims(%{"sub" => username}) do
     {:ok, username}
   end
 
-  def resource_from_claims(_), do: {:error, :invalid_claims}
+  def resource_from_claims(_claims), do: {:error, :invalid_claims}
 
   @spec claims_access_level(Guardian.Token.claims()) :: access_level()
   def claims_access_level(%{"groups" => groups}) do

--- a/lib/draft_web/auth_manager/ensure_admin_group.ex
+++ b/lib/draft_web/auth_manager/ensure_admin_group.ex
@@ -6,8 +6,10 @@ defmodule DraftWeb.AuthManager.EnsureAdminGroup do
 
   alias DraftWeb.Router.Helpers
 
+  @spec init(Plug.opts()) :: Plug.opts()
   def init(options), do: options
 
+  @spec call(Plug.Conn.t(), Plug.opts()) :: Plug.Conn.t()
   def call(conn, _opts) do
     claims = Guardian.Plug.current_claims(conn)
 

--- a/lib/draft_web/auth_manager/ensure_admin_group.ex
+++ b/lib/draft_web/auth_manager/ensure_admin_group.ex
@@ -2,14 +2,15 @@ defmodule DraftWeb.AuthManager.EnsureAdminGroup do
   @moduledoc """
   Ensure the user is part of the draft-admin user group.
   """
+  @behaviour Plug
   import Plug.Conn
 
   alias DraftWeb.Router.Helpers
 
-  @spec init(Plug.opts()) :: Plug.opts()
+  @impl Plug
   def init(options), do: options
 
-  @spec call(Plug.Conn.t(), Plug.opts()) :: Plug.Conn.t()
+  @impl Plug
   def call(conn, _opts) do
     claims = Guardian.Plug.current_claims(conn)
 

--- a/lib/draft_web/controllers/admin_controller.ex
+++ b/lib/draft_web/controllers/admin_controller.ex
@@ -1,6 +1,7 @@
 defmodule DraftWeb.AdminController do
   use DraftWeb, :controller
 
+  @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
     render(conn, "index.html")
   end

--- a/lib/draft_web/controllers/admin_controller.ex
+++ b/lib/draft_web/controllers/admin_controller.ex
@@ -1,7 +1,7 @@
 defmodule DraftWeb.AdminController do
   use DraftWeb, :controller
 
-  @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
+  @spec index(Plug.Conn.t(), map) :: Plug.Conn.t()
   def index(conn, _params) do
     render(conn, "index.html")
   end

--- a/lib/draft_web/controllers/auth_controller.ex
+++ b/lib/draft_web/controllers/auth_controller.ex
@@ -1,12 +1,13 @@
 defmodule DraftWeb.AuthController do
   use DraftWeb, :controller
-  require Logger
-
-  plug(Ueberauth)
 
   alias DraftWeb.AuthManager
   alias DraftWeb.Router.Helpers
 
+  plug(Ueberauth)
+  require Logger
+
+  @spec callback(Plug.Conn.t(), any) :: Plug.Conn.t()
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     username = auth.uid
     credentials = auth.credentials

--- a/lib/draft_web/controllers/auth_controller.ex
+++ b/lib/draft_web/controllers/auth_controller.ex
@@ -27,6 +27,8 @@ defmodule DraftWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
-    send_resp(conn, 401, "unauthenticated")
+    require Logger
+    Logger.error(_fails)
+    send_resp(conn, 401, "unauthenticated testing")
   end
 end

--- a/lib/draft_web/controllers/auth_controller.ex
+++ b/lib/draft_web/controllers/auth_controller.ex
@@ -27,8 +27,6 @@ defmodule DraftWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
-    require Logger
-    Logger.error(_fails)
-    send_resp(conn, 401, "unauthenticated testing")
+    send_resp(conn, 401, "unauthenticated")
   end
 end

--- a/lib/draft_web/controllers/health_controller.ex
+++ b/lib/draft_web/controllers/health_controller.ex
@@ -5,6 +5,7 @@ defmodule DraftWeb.HealthController do
   """
   use DraftWeb, :controller
 
+  @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
     send_resp(conn, 200, "")
   end

--- a/lib/draft_web/controllers/page_controller.ex
+++ b/lib/draft_web/controllers/page_controller.ex
@@ -1,6 +1,7 @@
 defmodule DraftWeb.PageController do
   use DraftWeb, :controller
 
+  @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
     render(conn, "index.html")
   end

--- a/lib/draft_web/telemetry.ex
+++ b/lib/draft_web/telemetry.ex
@@ -5,6 +5,7 @@ defmodule DraftWeb.Telemetry do
   use Supervisor
   import Telemetry.Metrics
 
+  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end

--- a/lib/draft_web/telemetry.ex
+++ b/lib/draft_web/telemetry.ex
@@ -5,7 +5,7 @@ defmodule DraftWeb.Telemetry do
   use Supervisor
   import Telemetry.Metrics
 
-  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
+  @spec start_link(any) :: Supervisor.on_start()
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end

--- a/lib/draft_web/views/error_helpers.ex
+++ b/lib/draft_web/views/error_helpers.ex
@@ -8,7 +8,7 @@ defmodule DraftWeb.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  @spec error_tag(HTML.form(), String.t()) :: String.t()
+  @spec error_tag(%{:errors => [{String.t(), any()}]}, atom()) :: [any()]
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
       content_tag(:span, translate_error(error),

--- a/lib/draft_web/views/error_helpers.ex
+++ b/lib/draft_web/views/error_helpers.ex
@@ -8,6 +8,7 @@ defmodule DraftWeb.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
+  @spec error_tag(HTML.form(), String.t()) :: String.t()
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
       content_tag(:span, translate_error(error),
@@ -20,6 +21,7 @@ defmodule DraftWeb.ErrorHelpers do
   @doc """
   Translates an error message using gettext.
   """
+  @spec translate_error({String.t(), any()}) :: String.t()
   def translate_error({msg, opts}) do
     # When using gettext, we typically pass the strings we want
     # to translate as a static argument:

--- a/lib/draft_web/views/error_view.ex
+++ b/lib/draft_web/views/error_view.ex
@@ -11,7 +11,7 @@ defmodule DraftWeb.ErrorView do
   # the template name. For example, "404.html" becomes
   # "Not Found".
 
-  @spec template_not_found(String.t(), map()) :: String.t()
+  @spec template_not_found(String.t(), map) :: String.t()
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/lib/draft_web/views/error_view.ex
+++ b/lib/draft_web/views/error_view.ex
@@ -11,7 +11,7 @@ defmodule DraftWeb.ErrorView do
   # the template name. For example, "404.html" becomes
   # "Not Found".
 
-  @spec template_not_found(String.t(), any()) :: String.t()
+  @spec template_not_found(String.t(), map()) :: String.t()
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/lib/draft_web/views/error_view.ex
+++ b/lib/draft_web/views/error_view.ex
@@ -10,6 +10,8 @@ defmodule DraftWeb.ErrorView do
   # By default, Phoenix returns the status message from
   # the template name. For example, "404.html" becomes
   # "Not Found".
+
+  @spec template_not_found(String.t(), any()) :: String.t()
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/test/draft/repo_test.exs
+++ b/test/draft/repo_test.exs
@@ -2,7 +2,13 @@ defmodule Draft.RepoTest do
   use ExUnit.Case, async: false
 
   defmodule FakeAwsRds do
-    def generate_db_auth_token(_, _, _, _) do
+    @spec generate_db_auth_token(
+            hostname :: String.t(),
+            username :: String.t(),
+            port :: integer(),
+            config :: map()
+          ) :: String.t()
+    def generate_db_auth_token(_username, _hostname, _port, _config) do
       "iam_token"
     end
   end

--- a/test/draft/ueberauth/strategy/fake_test.exs
+++ b/test/draft/ueberauth/strategy/fake_test.exs
@@ -2,7 +2,9 @@ defmodule Draft.Ueberauth.Strategy.FakeTest do
   use ExUnit.Case, async: true
 
   alias Draft.Ueberauth.Strategy.Fake
-  alias Ueberauth.Auth.{Credentials, Extra, Info}
+  alias Ueberauth.Auth.Credentials
+  alias Ueberauth.Auth.Extra
+  alias Ueberauth.Auth.Info
 
   test "credentials returns a credentials struct" do
     assert Fake.credentials(%{}) == %Credentials{

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -39,6 +39,7 @@ defmodule Draft.DataCase do
     :ok
   end
 
+  @spec errors_on(Ecto.Changeset.t()) :: %{optional(atom) => [binary | map]}
   @doc """
   A helper that transforms changeset errors into a map of messages.
 
@@ -49,7 +50,7 @@ defmodule Draft.DataCase do
   """
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+      Regex.replace(~r"%{(\w+)}", message, fn _arg, key ->
         opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)


### PR DESCRIPTION
I've enabled the majority of the optional credo functions and made the recommended changes. 
The changes here represent catches by the following new checks:
* Credo.Check.Readability.Specs
* Credo.Check.Readability.MultiAlias
* Credo.Check.Readability.StrictModuleLayout
* Credo.Check.Consistency.UnusedVariableNames

The three checks below I've opted not to enable for now, but would be open to enabling if beneficial! 
* Credo.Check.Refactor.ModuleDependencies
         * Only core modules have > 10
* Credo.Check.Warning.MixEnv
         * Used only for exposing telemetry dashboard in test / dev
* Credo.Check.Readability.AliasAs
          * Used by default for `alias DraftWeb.Router.Helpers, as: Routes`, which seems like a common convention
   
![image](https://user-images.githubusercontent.com/31781298/118305135-92ce3580-b4b5-11eb-8fdc-4bd15f0be2fe.png)
