### PR TITLE
Enable http redirect with SSL plug

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@
 use Mix.Config
 
 config :draft,
-  ecto_repos: [Draft.Repo]
+  ecto_repos: [Draft.Repo],
+  redirect_http?: true
 
 config :draft, Draft.Repo,
   show_sensitive_data_on_connection_error: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :draft, :redirect_http?, false
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,7 +2,8 @@ use Mix.Config
 
 config :draft, Draft.Repo,
   aws_rds_mod: ExAws.RDS,
-  show_sensitive_data_on_connection_error: false
+  show_sensitive_data_on_connection_error: false,
+  ssl: true
 
 # For production, don't forget to configure the url host
 # to something meaningful, Phoenix uses this information

--- a/lib/draft_web/router.ex
+++ b/lib/draft_web/router.ex
@@ -25,13 +25,18 @@ defmodule DraftWeb.Router do
     plug(DraftWeb.AuthManager.EnsureAdminGroup)
   end
 
+  pipeline :redirect_http do
+    if Application.get_env(:draft, :redirect_http?) do
+      plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
+    end
+  end
+
   scope "/", DraftWeb do
     get "/_health", HealthController, :index
   end
 
   scope "/", DraftWeb do
-    pipe_through [:browser, :auth, :ensure_auth]
-
+    pipe_through [:redirect_http, :browser, :auth, :ensure_auth]
     get "/", PageController, :index
   end
 
@@ -42,7 +47,7 @@ defmodule DraftWeb.Router do
   end
 
   scope "/admin", DraftWeb do
-    pipe_through [:browser, :auth, :ensure_auth, :ensure_admin]
+    pipe_through [:redirect_http, :browser, :auth, :ensure_auth, :ensure_admin]
 
     get "/", AdminController, :index
   end

--- a/test/draft_web/controllers/page_controller_test.exs
+++ b/test/draft_web/controllers/page_controller_test.exs
@@ -6,4 +6,21 @@ defmodule DraftWeb.PageControllerTest do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "Welcome!"
   end
+
+  @tag :authenticated
+  test "GET / with HTTP redirects to HTTPS", %{conn: conn} do
+    conn = conn |> Plug.Conn.put_req_header("x-forwarded-proto", "http") |> get("/")
+
+    location_header = Enum.find(conn.resp_headers, fn {key, _value} -> key == "location" end)
+    {"location", url} = location_header
+    assert url =~ "https"
+
+    assert response(conn, 301)
+  end
+
+  @tag :authenticated
+  test "GET / with HTTPS results in 200", %{conn: conn} do
+    conn = conn |> Plug.Conn.put_req_header("x-forwarded-proto", "https") |> get("/")
+    assert response(conn, 200)
+  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -40,13 +40,17 @@ defmodule DraftWeb.ConnCase do
       Sandbox.mode(Draft.Repo, {:shared, self()})
     end
 
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_req_header("x-forwarded-proto", "https")
+
     cond do
       tags[:authenticated] ->
         user = "test_user"
 
         conn =
-          Phoenix.ConnTest.build_conn()
-          |> init_test_session(%{arrow_username: user})
+          conn
+          |> init_test_session(%{username: user})
           |> Guardian.Plug.sign_in(DraftWeb.AuthManager, user, %{})
 
         {:ok, conn: conn}
@@ -55,14 +59,14 @@ defmodule DraftWeb.ConnCase do
         user = "test_user"
 
         conn =
-          Phoenix.ConnTest.build_conn()
+          conn
           |> init_test_session(%{})
           |> Guardian.Plug.sign_in(DraftWeb.AuthManager, user, %{groups: ["draft-admin"]})
 
         {:ok, conn: conn}
 
       true ->
-        {:ok, conn: Phoenix.ConnTest.build_conn()}
+        {:ok, conn: conn}
     end
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -40,9 +40,7 @@ defmodule DraftWeb.ConnCase do
       Sandbox.mode(Draft.Repo, {:shared, self()})
     end
 
-    conn =
-      Phoenix.ConnTest.build_conn()
-      |> Plug.Conn.put_req_header("x-forwarded-proto", "https")
+    conn = Plug.Conn.put_req_header(Phoenix.ConnTest.build_conn(), "x-forwarded-proto", "https")
 
     cond do
       tags[:authenticated] ->


### PR DESCRIPTION
This PR enables SSL for certain endpoints (only will exclude healthcheck & auth endpoints). Referred to [this Arrow PR ](https://github.com/mbta/arrow/pull/6) for my approach here. 