### PR TITLE
Fix IAM-RDS Authentication 

### DIFF
--- a/lib/draft/repo.ex
+++ b/lib/draft/repo.ex
@@ -12,7 +12,7 @@ defmodule Draft.Repo do
   """
   @spec before_connect(map()) :: map()
   def before_connect(config) do
-    mod = Application.get_env(:draft, :aws_rds_mod)
+    mod = Application.get_env(:draft, Draft.Repo)[:aws_rds_mod]
 
     if mod do
       :ok = Logger.info("generating_aws_rds_iam_auth_token")

--- a/test/draft/repo_test.exs
+++ b/test/draft/repo_test.exs
@@ -22,10 +22,13 @@ defmodule Draft.RepoTest do
     end
 
     test "generates RDS IAM auth token if rds module is configured" do
-      Application.put_env(:draft, :aws_rds_mod, FakeAwsRds)
+      initial_repo_config = Application.get_env(:draft, Draft.Repo)
+      updated_config = Keyword.put(initial_repo_config, :aws_rds_mod, FakeAwsRds)
+
+      Application.put_env(:draft, Draft.Repo, updated_config)
       config = Draft.Repo.before_connect(username: "u", hostname: "h", port: 4000)
       assert Keyword.fetch!(config, :password) == "iam_token"
-      on_exit(fn -> Application.put_env(:draft, :aws_rds_mod, nil) end)
+      on_exit(fn -> Application.put_env(:draft, Draft.Repo, initial_repo_config) end)
     end
   end
 end


### PR DESCRIPTION
In [0ab259399b0d27d17549dd25666e9a8b948d0c0a](https://github.com/mbta/draft/pull/6/commits/0ab259399b0d27d17549dd25666e9a8b948d0c0a), I moved configuring the AWS RDS module from the top-level :draft root key into the more specific Draft.Repo key. However, I did not update the usage of this module or the tests to reflect that change, so while the tests still passed, they were no longer accurate. 

Now, the configuration is appropriately read from the Draft.Repo key, and the test has been updated to follow suit. 