### PR TITLE
Enable auto-deploy when merging to main branch

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -3,7 +3,7 @@ name: Deploy to ECS (Dev)
 on:
   workflow_dispatch:
   push:
-    branches: [$default_branch]
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
Replaces `$default_branch` placeholder with `main` so that pushes to the main branch will automatically trigger a deploy to the dev environment. 